### PR TITLE
Fix build error and prevent index out of range error

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -246,8 +246,8 @@ func (r *Registry) fetchPackageData(name string) (*repoPackageData, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !compareLatest || sv.LTE(latest) {
-			p.sortedVersions = append(p.sortedVersions, sv)
+		if !compareLatest || sv.LTE(*latest) {
+			p.sortedVersions = append(p.sortedVersions, *sv)
 		}
 	}
 	sort.Sort(sort.Reverse(p.sortedVersions))

--- a/semver.go
+++ b/semver.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/blang/semver"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -27,25 +28,11 @@ var cleanup = strings.NewReplacer("  ", " ", "> ", ">", "= ", "=", "< ", "<")
 
 //strips any prefix for the version for parsing
 func stripPrefix(version string) string {
-	// Avoiding index out of range errors.
-	if len(version) > 0 {
-		switch version[0] {
-		case '>', '<':
-			if len(version) > 1 && version[1] == '=' {
-				version = version[2:]
-			} else {
-				version = version[1:]
-			}
-		case '=', '^', '~':
-			version = version[1:]
-		}
+	// Stripping out prefix semver range characters
+	var re = regexp.MustCompile("^[><^~]?=?v?")
+	strippedVersion := re.ReplaceAllString(version, "")
 
-		if len(version) > 0 && version[0] == 'v' {
-			version = version[1:]
-		}
-	}
-
-	return version
+	return strippedVersion
 }
 
 //parses, replacing missing/wildcards with zero

--- a/semver.go
+++ b/semver.go
@@ -25,15 +25,7 @@ type SemverRequirements struct {
 }
 
 var cleanup = strings.NewReplacer("  ", " ", "> ", ">", "= ", "=", "< ", "<")
-
-//strips any prefix for the version for parsing
-func stripPrefix(version string) string {
-	// Stripping out prefix semver range characters
-	var re = regexp.MustCompile("^[><^~]?=?v?")
-	strippedVersion := re.ReplaceAllString(version, "")
-
-	return strippedVersion
-}
+var stripPrefixRx = regexp.MustCompile("^([=^~]|[><]=?)?v?")
 
 //parses, replacing missing/wildcards with zero
 func parseDown(version string) (sv semver.Version, err error) {
@@ -175,7 +167,9 @@ func NewSemverRequirements(requirements string) (*SemverRequirements, error) {
 		if i == 0 || parts[i-1] == "||" {
 			currentSet = make([]requirement, 0, len(parts)-i)
 		}
-		clean := stripPrefix(parts[i])
+
+		// strips any prefix for the version for parsing
+		clean := stripPrefixRx.ReplaceAllString(parts[i], "")
 		vLow, err := parseDown(clean)
 		if err != nil {
 			return nil, err

--- a/semver.go
+++ b/semver.go
@@ -27,19 +27,22 @@ var cleanup = strings.NewReplacer("  ", " ", "> ", ">", "= ", "=", "< ", "<")
 
 //strips any prefix for the version for parsing
 func stripPrefix(version string) string {
-	switch version[0] {
-	case '>', '<':
-		if version[1] == '=' {
-			version = version[2:]
-		} else {
+	// Avoiding index out of range errors.
+	if len(version) > 0 {
+		switch version[0] {
+		case '>', '<':
+			if len(version) > 1 && version[1] == '=' {
+				version = version[2:]
+			} else {
+				version = version[1:]
+			}
+		case '=', '^', '~':
 			version = version[1:]
 		}
-	case '=', '^', '~':
-		version = version[1:]
-	}
 
-	if version[0] == 'v' {
-		version = version[1:]
+		if len(version) > 0 && version[0] == 'v' {
+			version = version[1:]
+		}
 	}
 
 	return version

--- a/semver_test.go
+++ b/semver_test.go
@@ -97,25 +97,24 @@ func TestNewSemverRequirements_tilde(t *testing.T) {
 	check("~1.2.3-beta.2", []string{"1.2.3-beta.2", "1.2.3", "1.2.4", "1.2.3-beta.3"}, []string{"1.2.2", "1.0.0", "1.2.4-beta.2", "1.3.0"})
 }
 
-func TestNewSemverRequirements_bad(t *testing.T) {
-	// Ensuring error was returned and index out of range error does not occur.
-	_, err := NewSemverRequirements(">=")
+func TestNewSemverRequirements_invalid(t *testing.T) {
+	check := func(semverStr string) {
+		_, err := NewSemverRequirements(semverStr)
 
-	if err == nil {
-		t.Errorf("Failed to properly error for invalid semver '>='")
+		if err == nil {
+			t.Errorf("check '%s': got nil, expected err", semverStr)
+		}
 	}
 
-	_, err = NewSemverRequirements(">")
-
-	if err == nil {
-		t.Errorf("Failed to properly error for invalid semver '>'")
-	}
-
-	_, err = NewSemverRequirements("~")
-
-	if err == nil {
-		t.Errorf("Failed to properly error for invalid semver '~'")
-	}
+	check("<=")
+	check("<")
+	check(">=")
+	check(">")
+	check("~")
+	check("^")
+	check("💩")
+	check("💩💩")
+	check("=<")
 }
 
 func TestParseDown(t *testing.T) {

--- a/semver_test.go
+++ b/semver_test.go
@@ -97,6 +97,27 @@ func TestNewSemverRequirements_tilde(t *testing.T) {
 	check("~1.2.3-beta.2", []string{"1.2.3-beta.2", "1.2.3", "1.2.4", "1.2.3-beta.3"}, []string{"1.2.2", "1.0.0", "1.2.4-beta.2", "1.3.0"})
 }
 
+func TestNewSemverRequirements_bad(t *testing.T) {
+	// Ensuring error was returned and index out of range error does not occur.
+	_, err := NewSemverRequirements(">=")
+
+	if err == nil {
+		t.Errorf("Failed to properly error for invalid semver '>='")
+	}
+
+	_, err = NewSemverRequirements(">")
+
+	if err == nil {
+		t.Errorf("Failed to properly error for invalid semver '>'")
+	}
+
+	_, err = NewSemverRequirements("~")
+
+	if err == nil {
+		t.Errorf("Failed to properly error for invalid semver '~'")
+	}
+}
+
 func TestParseDown(t *testing.T) {
 	check := func(input, expected string) {
 		ex, err := semver.Parse(expected)


### PR DESCRIPTION
Not sure if you remember the depscanner that builds an index for Neo4j for dependency management at good ol Best Buy, but we are running into issues due to a malformed version in a particular package. Rather then tracking that down, I figured I would make the prefix remove safer to avoid a panic. I sort of threw a solution together to correct it, let me know if you want any changes or better tests.